### PR TITLE
Fix IE 11 regression. Need to use svgClasses on svg elements.

### DIFF
--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -8,6 +8,7 @@ import {
 import {
   append as svgAppend,
   attr as svgAttr,
+  classes as svgClasses,
   create as svgCreate,
   remove as svgRemove
 } from 'tiny-svg';
@@ -371,7 +372,7 @@ Minimap.prototype._init = function() {
   // add viewport
   var viewport = this._viewport = svgCreate('rect');
 
-  domClasses(viewport).add('viewport');
+  svgClasses(viewport).add('viewport');
 
   svgAppend(viewportGroup, viewport);
 


### PR DESCRIPTION
resolves issue #25 
Tested with the minimap example.
