### PR TITLE
Infinity and NaN managed in Minimap's _update function

### DIFF
--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -471,8 +471,8 @@ Minimap.prototype._update = function() {
   svgAttr(this._viewport, {
     x: viewbox.x,
     y: viewbox.y,
-    width: viewbox.width,
-    height: viewbox.height
+    width: (viewbox.width===Infinity ? '100%' : viewbox.width) || this._lastViewbox.width,
+    height: (viewbox.height===Infinity ? '100%' : viewbox.height) || this._lastViewbox.height
   });
 
   // update viewport DOM


### PR DESCRIPTION
This PR is intended to fix a minor issue of the minimap plugin that occurs in apps that goes beyond the simple examples reported in the bpmnjs repositories.
Using the plugin in my own proprietary app, it happens that at runtime, within the "_update" function of the Minimap object, it can happen that during the assignment:

```
// update viewport SVG
svgAttr(this._viewport, {
  x: viewbox.x,
  y: viewbox.y,
  width: viewbox.width,
  height: viewbox.height
});
```

The "width" and "height" fields of the "viewbox" object can be either "NaN" or "Infinity".
These values generate errors that leave their presence on the console but that do not seem to be blocking.
I repeat: in any of the example apps published by you all this does not happen but within other apps differently structured, instead it can happen.
To correct the anomalous values we proceeded in this way.
For the value "Infinity" we use the attribute value "100%".
For the value "NaN" (or "null") we use the previous value stored inside the object "_lastViewbox".
These corrections ensure that the attributes are assigned correctly and therefore do not generate errors.
