### PR TITLE
Ensure viewbox is changing error-free on mousemove

### DIFF
--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -73,7 +73,7 @@ export default function Minimap(
     var diagramPoint = mapMousePositionToDiagramPoint({
       x: event.clientX - self._state._svgClientRect.left,
       y: event.clientY - self._state._svgClientRect.top
-    }, self._canvas, self._svg, self._lastViewbox);
+    }, self._svg, self._lastViewbox);
 
     setViewboxCenteredAroundPoint(diagramPoint, self._canvas);
 
@@ -104,7 +104,7 @@ export default function Minimap(
       var diagramPoint = mapMousePositionToDiagramPoint({
         x: event.clientX - self._state._svgClientRect.left,
         y: event.clientY - self._state._svgClientRect.top
-      }, self._canvas, self._svg, self._lastViewbox);
+      }, self._svg, self._lastViewbox);
 
       var viewbox = canvas.viewbox();
 
@@ -172,7 +172,7 @@ export default function Minimap(
       var diagramPoint = mapMousePositionToDiagramPoint({
         x: event.clientX - self._state._svgClientRect.left,
         y: event.clientY - self._state._svgClientRect.top
-      }, self._canvas, self._svg, self._lastViewbox);
+      }, self._svg, self._lastViewbox);
 
       setViewboxCenteredAroundPoint({
         x: diagramPoint.x - self._state.offsetViewport.x,
@@ -270,7 +270,7 @@ export default function Minimap(
       var diagramPoint = mapMousePositionToDiagramPoint({
         x: event.clientX - self._state._svgClientRect.left,
         y: event.clientY - self._state._svgClientRect.top
-      }, self._canvas, self._svg, self._lastViewbox);
+      }, self._svg, self._lastViewbox);
 
       setViewboxCenteredAroundPoint(diagramPoint, self._canvas);
 
@@ -686,14 +686,13 @@ function getOffsetViewport(diagramPoint, viewbox) {
   };
 }
 
-function mapMousePositionToDiagramPoint(position, canvas, svg, lastViewbox) {
+function mapMousePositionToDiagramPoint(position, svg, lastViewbox) {
 
   // firefox returns 0 for clientWidth and clientHeight
   var boundingClientRect = svg.getBoundingClientRect();
 
   // take different aspect ratios of default layers bounding box and minimap into account
   var bBox =
-    // fitAspectRatio(canvas.getDefaultLayer().getBBox(), boundingClientRect.width / boundingClientRect.height);
     fitAspectRatio(lastViewbox, boundingClientRect.width / boundingClientRect.height);
 
   // map click position to diagram position

--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -16,7 +16,8 @@ import {
 import {
   assign,
   every,
-  isNumber
+  isNumber,
+  isObject
 } from 'min-dash';
 
 import cssEscape from 'css.escape';
@@ -858,7 +859,14 @@ function toCoordinatesString(x, y) {
 }
 
 function validViewbox(viewBox) {
+
   return every(viewBox, function(value) {
+
+    // check deeper structures like inner or outer viewbox
+    if (isObject(value)) {
+      return validViewbox(value);
+    }
+
     return isNumber(value) && isFinite(value);
   });
 }

--- a/test/spec/MinimapSpec.js
+++ b/test/spec/MinimapSpec.js
@@ -186,10 +186,58 @@ describe('minimap', function() {
       canvas.viewbox({
         x: 0,
         y: 0,
+        width: 100,
+        height: 100
+      });
+    });
+
+
+    it('should not error on viewbox changed (malformed values)', function() {
+      var diagram = new Diagram({
+        modules: modelerModules
+      });
+
+      var canvas = diagram.get('canvas');
+
+      canvas.viewbox({
+        x: 0,
+        y: 0,
         width: Infinity,
         height: Infinity
       });
     });
+
+  });
+
+
+  describe('mousemove', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: viewerModules,
+      minimap: {
+        open: true
+      }
+    }));
+
+    it('should change viewbox on mousemove', inject(function(eventBus, minimap) {
+
+      // given
+      var svg = minimap._svg;
+
+      var listener = sinon.spy();
+
+      eventBus.on('canvas.viewbox.changing', listener);
+
+      // when
+      triggerMouseEvent('mousedown', svg);
+      triggerMouseEvent('mousemove', svg);
+      triggerMouseEvent('mousemove', svg);
+
+      // then
+      // 1 mousedown + 2 mousemove
+      expect(listener).to.have.been.calledThrice;
+
+    }));
 
   });
 
@@ -219,7 +267,15 @@ function generateShapes(count, viewport) {
   });
 }
 
-
 function rnd(start, end) {
   return Math.round(Math.random() * (end - start) + start);
 }
+
+function triggerMouseEvent(type, gfx) {
+
+  var event = document.createEvent('MouseEvent');
+  event.initMouseEvent(type, true, true, window, 0, 0, 0, 80, 20, false, false, false, false, 0, null);
+
+  return gfx.dispatchEvent(event);
+}
+


### PR DESCRIPTION
This ensures the minimap does not run into errors on `mousemove`. It adds a regression fix for the  recent added `validViewbox` check to ensure `inner` and `outer` viewbox got deeply checked instead of not recognized as `Number` (since they are objects).

Closes #36 

![Aug-07-2019 09-37-27](https://user-images.githubusercontent.com/9433996/62603803-fe559d00-b8f6-11e9-9dd9-9ee48617f758.gif)
