### PR TITLE
fix css toggle-button ignores title translation

### DIFF
--- a/assets/diagram-js-minimap.css
+++ b/assets/diagram-js-minimap.css
@@ -35,8 +35,7 @@
   text-align: center;
 }
 
-.djs-minimap:not(.open) .toggle:before,
-.djs-minimap.open .toggle:before {
+.djs-minimap .toggle:before {
   content: attr(title);
 }
 

--- a/assets/diagram-js-minimap.css
+++ b/assets/diagram-js-minimap.css
@@ -31,14 +31,13 @@
 }
 
 .djs-minimap:not(.open) .toggle {
-  width: 46px;
-  height: 46px;
-  line-height: 46px;
+  padding: 10px;
   text-align: center;
 }
 
-.djs-minimap:not(.open) .toggle:before {
-  content: 'Open';
+.djs-minimap:not(.open) .toggle:before,
+.djs-minimap.open .toggle:before {
+  content: attr(title);
 }
 
 .djs-minimap.open .toggle {
@@ -46,10 +45,6 @@
   right: 0;
   padding: 6px;
   z-index: 1;
-}
-
-.djs-minimap.open .toggle:before {
-  content: 'Close';
 }
 
 .djs-minimap .map {


### PR DESCRIPTION
Unfortunately, the current implementation ignores translations and the buttons texts are hardcoded inside the css. 
The easiest fix is to use the title attribute of the parent div that is already translated.

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #43
