### PR TITLE
Fix: ensure combatibility with older diagram-js versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,38 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  Build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [14]
+        integration-deps:
+          - "" # as defined in package.json
+          - diagram-js@7.x
+          - diagram-js@6.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Install dependencies for integration test
+        if: ${{ matrix.integration-deps != '' }}
+        run: npm install ${{ matrix.integration-deps }}
+      - name: Build
+        run: npm run all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language:
-  - node_js
-
-node_js:
-  - node
-
-script:
-  - npm run all

--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -345,10 +345,12 @@ export default function Minimap(
 
   });
 
-  eventBus.on('root.set', function(event) {
+  eventBus.on(['root.set', 'plane.set'], function(event) {
     self._clear();
 
-    event.element.children.forEach(function(el) {
+    var element = event.element || event.plane.rootElement;
+
+    element.children.forEach(function(el) {
       self._addElement(el);
     });
 
@@ -600,6 +602,27 @@ Minimap.prototype._updateElementId = function(element, newId) {
 };
 
 /**
+ * Checks if an element is on the currently active plane.
+ */
+Minimap.prototype.isOnActivePlane = function(element) {
+  var canvas = this._canvas;
+
+  // diagram-js@8
+  if (canvas.findRoot) {
+    return canvas.findRoot(element) === canvas.getRootElement();
+  }
+
+  // diagram-js>=7.4.0
+  if (canvas.findPlane) {
+    return canvas.findPlane(element) === canvas.getActivePlane();
+  }
+
+  // diagram-js<7.4.0
+  return true;
+};
+
+
+/**
  * Adds an element to the minimap.
  */
 Minimap.prototype._addElement = function(element) {
@@ -607,7 +630,7 @@ Minimap.prototype._addElement = function(element) {
 
   this._removeElement(element);
 
-  if (this._canvas.findRoot(element) !== this._canvas.getRootElement()) {
+  if (!this.isOnActivePlane(element)) {
     return;
   }
 

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -1,1 +1,24 @@
+import semver from 'semver';
+
 export * from 'diagram-js/test/helper';
+
+/**
+ * Execute test only if currently installed bpmn-js is of given version.
+ *
+ * @param {string} versionRange
+ * @param {boolean} only
+ */
+export function withDiagramJs(versionRange, only) {
+  if (diagramJsSatisfies(versionRange)) {
+    return only ? it.only : it;
+  } else {
+    return it.skip;
+  }
+}
+
+function diagramJsSatisfies(versionRange) {
+  var bpmnJsVersion = require('diagram-js/package.json').version;
+
+  return semver.satisfies(bpmnJsVersion, versionRange, { includePrerelease: true });
+}
+

--- a/test/spec/MinimapSpec.js
+++ b/test/spec/MinimapSpec.js
@@ -12,7 +12,8 @@ import {
   bootstrapDiagram,
   getDiagramJS,
   inject,
-  insertCSS
+  insertCSS,
+  withDiagramJs
 } from '../TestHelper';
 
 import minimapModule from '../../lib';
@@ -312,49 +313,96 @@ describe('minimap', function() {
       }
     }));
 
-    it('should only show elements of active plane', inject(function(canvas, elementFactory) {
+    withDiagramJs('>=8')('should only show elements of active plane',
+      inject(function(canvas, elementFactory) {
 
-      // given
-      var rootA = elementFactory.createRoot({
-        id: 'rootA'
-      });
-      var shapeA = elementFactory.createShape({
-        id: 'A',
-        width: 100,
-        height: 300,
-        x: 50,
-        y: 150
-      });
+        // given
+        var rootA = elementFactory.createRoot({
+          id: 'rootA'
+        });
+        var shapeA = elementFactory.createShape({
+          id: 'A',
+          width: 100,
+          height: 300,
+          x: 50,
+          y: 150
+        });
 
-      canvas.addRootElement(rootA);
-      canvas.addShape(shapeA, rootA);
+        canvas.addRootElement(rootA);
+        canvas.addShape(shapeA, rootA);
 
-      var rootB = elementFactory.createRoot({
-        id: 'rootB'
-      });
-      var shapeB = elementFactory.createShape({
-        id: 'B',
-        width: 100,
-        height: 300,
-        x: 50,
-        y: 150
-      });
+        var rootB = elementFactory.createRoot({
+          id: 'rootB'
+        });
+        var shapeB = elementFactory.createShape({
+          id: 'B',
+          width: 100,
+          height: 300,
+          x: 50,
+          y: 150
+        });
 
-      canvas.addRootElement(rootB);
-      canvas.addShape(shapeB, rootB);
-      canvas.setRootElement(rootA);
+        canvas.addRootElement(rootB);
+        canvas.addShape(shapeB, rootB);
+        canvas.setRootElement(rootA);
 
-      // assume
-      expectMinimapShapeToExist('A');
-      expectMinimapShapeToNotExist('B');
+        // assume
+        expectMinimapShapeToExist('A');
+        expectMinimapShapeToNotExist('B');
 
-      // when
-      canvas.setRootElement(rootB);
+        // when
+        canvas.setRootElement(rootB);
 
-      // then
-      expectMinimapShapeToNotExist('A');
-      expectMinimapShapeToExist('B');
-    }));
+        // then
+        expectMinimapShapeToNotExist('A');
+        expectMinimapShapeToExist('B');
+      }));
+
+
+    withDiagramJs('^7.4')('should only show elements of active plane',
+      inject(function(canvas, elementFactory) {
+
+        // given
+        var rootA = elementFactory.createRoot({
+          id: 'rootA'
+        });
+        var shapeA = elementFactory.createShape({
+          id: 'A',
+          width: 100,
+          height: 300,
+          x: 50,
+          y: 150
+        });
+
+        canvas.createPlane('A', rootA);
+        canvas.addShape(shapeA, rootA);
+
+        var rootB = elementFactory.createRoot({
+          id: 'rootB'
+        });
+        var shapeB = elementFactory.createShape({
+          id: 'B',
+          width: 100,
+          height: 300,
+          x: 50,
+          y: 150
+        });
+
+        canvas.createPlane('B', rootB);
+        canvas.addShape(shapeB, rootB);
+        canvas.setActivePlane('A');
+
+        // assume
+        expectMinimapShapeToExist('A');
+        expectMinimapShapeToNotExist('B');
+
+        // when
+        canvas.setActivePlane('B');
+
+        // then
+        expectMinimapShapeToNotExist('A');
+        expectMinimapShapeToExist('B');
+      }));
 
   });
 


### PR DESCRIPTION
This PR ensures that we are backwards compatible and adds integration tests against older diagram-js versions

closes #47

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
