### PR TITLE
Improve ID handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [diagram-js-minimap](https://github.com/bpmn-io/diagram-j
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support multiple diagram-js-instances on the same page
+* `FIX`: do not copy elements with IDs
+* `CHORE`: prefix svg graphic IDs
+
 ### 5.0.0
 
 * `CHORE`: drop hammerjs dependency ([#73](https://github.com/bpmn-io/diagram-js-minimap/issues/73))

--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -29,10 +29,11 @@ import {
 
 import { getVisual } from 'diagram-js/lib/util/GraphicsUtil';
 
+import IdGenerator from 'diagram-js/lib/util/IdGenerator';
 
 var MINIMAP_VIEWBOX_PADDING = 50;
 
-var ID_PREFIX = 'djs-minimap-';
+var IDS = new IdGenerator();
 
 var RANGE = { min: 0.2, max: 4 },
     NUM_STEPS = 10;
@@ -67,6 +68,8 @@ export default function Minimap(
     parentClientRect: null,
     zoomDelta: 0
   };
+
+  this._minimapId = IDS.next();
 
   this._init();
 
@@ -591,10 +594,10 @@ Minimap.prototype._updateElement = function(element) {
 Minimap.prototype._updateElementId = function(element, newId) {
 
   try {
-    var elementGfx = domQuery('#' + cssEscape(prefixId(element.id)), this._elementsGroup);
+    var elementGfx = domQuery('#' + cssEscape(this._prefixId(element.id)), this._elementsGroup);
 
     if (elementGfx) {
-      elementGfx.id = prefixId(newId);
+      elementGfx.id = this._prefixId(newId);
     }
   } catch (error) {
     console.warn('Minimap#_updateElementId errored', error);
@@ -639,7 +642,7 @@ Minimap.prototype._addElement = function(element) {
       x, y;
 
   var newElementGfx = this._createElement(element);
-  var newElementParentGfx = domQuery('#' + cssEscape(prefixId(element.parent.id)), this._elementsGroup);
+  var newElementParentGfx = domQuery('#' + cssEscape(this._prefixId(element.parent.id)), this._elementsGroup);
 
   if (newElementGfx) {
 
@@ -705,7 +708,7 @@ Minimap.prototype._addElement = function(element) {
 };
 
 Minimap.prototype._removeElement = function(element) {
-  var elementGfx = this._svg.getElementById(prefixId(element.id));
+  var elementGfx = this._svg.getElementById(this._prefixId(element.id));
 
   if (elementGfx) {
     svgRemove(elementGfx);
@@ -722,7 +725,7 @@ Minimap.prototype._createElement = function(element) {
     if (visual) {
       var elementGfx = sanitize(svgClone(visual));
 
-      svgAttr(elementGfx, { id: prefixId(element.id) });
+      svgAttr(elementGfx, { id: this._prefixId(element.id) });
 
       return elementGfx;
     }
@@ -732,6 +735,11 @@ Minimap.prototype._createElement = function(element) {
 Minimap.prototype._clear = function() {
   svgClear(this._elementsGroup);
 };
+
+Minimap.prototype._prefixId = function(id) {
+  return 'djs-minimap-' + id + '-' + this._minimapId;
+};
+
 
 function isConnection(element) {
   return element.waypoints;
@@ -959,10 +967,6 @@ function getPoint(event) {
     x: event.clientX,
     y: event.clientY
   };
-}
-
-function prefixId(id) {
-  return ID_PREFIX + id;
 }
 
 // removes all elements with an id attribute

--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -2,7 +2,8 @@ import {
   attr as domAttr,
   classes as domClasses,
   event as domEvent,
-  query as domQuery
+  query as domQuery,
+  queryAll as domQueryAll
 } from 'min-dom';
 
 import {
@@ -719,7 +720,7 @@ Minimap.prototype._createElement = function(element) {
     visual = getVisual(gfx);
 
     if (visual) {
-      var elementGfx = svgClone(visual);
+      var elementGfx = sanitize(svgClone(visual));
 
       svgAttr(elementGfx, { id: prefixId(element.id) });
 
@@ -962,4 +963,13 @@ function getPoint(event) {
 
 function prefixId(id) {
   return ID_PREFIX + id;
+}
+
+// removes all elements with an id attribute
+function sanitize(gfx) {
+  domQueryAll('[id]', gfx).forEach(function(element) {
+    element.remove();
+  });
+
+  return gfx;
 }

--- a/lib/Minimap.js
+++ b/lib/Minimap.js
@@ -31,6 +31,8 @@ import { getVisual } from 'diagram-js/lib/util/GraphicsUtil';
 
 var MINIMAP_VIEWBOX_PADDING = 50;
 
+var ID_PREFIX = 'djs-minimap-';
+
 var RANGE = { min: 0.2, max: 4 },
     NUM_STEPS = 10;
 
@@ -588,10 +590,10 @@ Minimap.prototype._updateElement = function(element) {
 Minimap.prototype._updateElementId = function(element, newId) {
 
   try {
-    var elementGfx = domQuery('#' + cssEscape(element.id), this._elementsGroup);
+    var elementGfx = domQuery('#' + cssEscape(prefixId(element.id)), this._elementsGroup);
 
     if (elementGfx) {
-      elementGfx.id = newId;
+      elementGfx.id = prefixId(newId);
     }
   } catch (error) {
     console.warn('Minimap#_updateElementId errored', error);
@@ -636,7 +638,7 @@ Minimap.prototype._addElement = function(element) {
       x, y;
 
   var newElementGfx = this._createElement(element);
-  var newElementParentGfx = domQuery('#' + cssEscape(element.parent.id), this._elementsGroup);
+  var newElementParentGfx = domQuery('#' + cssEscape(prefixId(element.parent.id)), this._elementsGroup);
 
   if (newElementGfx) {
 
@@ -702,7 +704,7 @@ Minimap.prototype._addElement = function(element) {
 };
 
 Minimap.prototype._removeElement = function(element) {
-  var elementGfx = this._svg.getElementById(element.id);
+  var elementGfx = this._svg.getElementById(prefixId(element.id));
 
   if (elementGfx) {
     svgRemove(elementGfx);
@@ -718,7 +720,8 @@ Minimap.prototype._createElement = function(element) {
 
     if (visual) {
       var elementGfx = svgClone(visual);
-      svgAttr(elementGfx, { id: element.id });
+
+      svgAttr(elementGfx, { id: prefixId(element.id) });
 
       return elementGfx;
     }
@@ -955,4 +958,8 @@ function getPoint(event) {
     x: event.clientX,
     y: event.clientY
   };
+}
+
+function prefixId(id) {
+  return ID_PREFIX + id;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "diagram-js": "^14.7.1",
         "eslint": "^8.56.0",
         "eslint-plugin-bpmn-io": "^1.0.0",
+        "inherits-browser": "^0.1.0",
         "karma": "^6.4.3",
         "karma-chrome-launcher": "^3.2.0",
         "karma-firefox-launcher": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "diagram-js": "^14.7.1",
     "eslint": "^8.56.0",
     "eslint-plugin-bpmn-io": "^1.0.0",
+    "inherits-browser": "^0.1.0",
     "karma": "^6.4.3",
     "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.3",

--- a/test/spec/MinimapSpec.js
+++ b/test/spec/MinimapSpec.js
@@ -508,7 +508,7 @@ function expectMinimapShapeToExist(id) {
 
     expect(element).to.exist;
 
-    var minimapShape = domQuery('g#djs-minimap-' + id, minimap._parent);
+    var minimapShape = domQuery(`g[id^="djs-minimap-${id}"]`, minimap._parent);
 
     expect(minimapShape).to.exist;
 
@@ -533,7 +533,7 @@ function expectMinimapConnectionToExist(id) {
 
     expect(element).to.exist;
 
-    var minimapShape = domQuery('g#djs-minimap-' + id, minimap._parent);
+    var minimapShape = domQuery(`g[id^="djs-minimap-${id}"]`, minimap._parent);
 
     expect(minimapShape).to.exist;
   });

--- a/test/spec/MinimapSpec.js
+++ b/test/spec/MinimapSpec.js
@@ -454,7 +454,7 @@ function expectMinimapShapeToExist(id) {
 
     expect(element).to.exist;
 
-    var minimapShape = domQuery('g#' + id, minimap._parent);
+    var minimapShape = domQuery('g#djs-minimap-' + id, minimap._parent);
 
     expect(minimapShape).to.exist;
 

--- a/test/spec/marker-renderer/MarkerRenderer.js
+++ b/test/spec/marker-renderer/MarkerRenderer.js
@@ -1,0 +1,137 @@
+import inherits from 'inherits-browser';
+
+import {
+  append as svgAppend,
+  attr as svgAttr,
+  create as svgCreate
+} from 'tiny-svg';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import DefaultRenderer from 'diagram-js/lib/draw/DefaultRenderer';
+
+import {
+  createLine
+} from 'diagram-js/lib/util/RenderUtil';
+
+/**
+ * @typedef {import('../../model').Connection} Connection
+ */
+
+var HIGH_PRIORITY = 3000;
+
+var CONNECTION_STYLE = {
+  fill: 'none',
+  stroke: 'fuchsia',
+  strokeWidth: 5
+};
+
+var MARKER_TYPES = [
+  'marker-start',
+  'marker-mid',
+  'marker-end'
+];
+
+/**
+ * A renderer that can render markers.
+ */
+export default function MarkerRenderer(canvas, eventBus, styles) {
+  DefaultRenderer.call(this, eventBus, styles, HIGH_PRIORITY);
+
+  this._canvas = canvas;
+}
+
+inherits(MarkerRenderer, DefaultRenderer);
+
+MarkerRenderer.$inject = [
+  'canvas',
+  'eventBus',
+  'styles'
+];
+
+MarkerRenderer.prototype.canRender = function() {
+  return true;
+};
+
+MarkerRenderer.prototype.drawConnection = function(parentGfx, connection) {
+  var line = createLine(connection.waypoints, CONNECTION_STYLE);
+
+  svgAppend(parentGfx, line);
+
+  var self = this;
+
+  MARKER_TYPES.forEach(function(markerType) {
+    if (hasMarker(connection, markerType)) {
+      self.addMarker(parentGfx, line, markerType, connection.id);
+    }
+  });
+
+  return line;
+};
+
+MarkerRenderer.prototype.addMarker = function(parentGfx, gfx, markerType, id) {
+  var defs, marker;
+  parentGfx = parentGfx || this._canvas._svg;
+
+  marker = svgCreate('marker');
+
+  marker.id = markerType + '-' + id;
+
+  svgAttr(marker, {
+    refX: 5,
+    refY: 5,
+    viewBox: '0 0 10 10'
+  });
+
+  var circle = svgCreate('circle');
+
+  svgAttr(circle, {
+    cx: 5,
+    cy: 5,
+    fill: 'fuchsia',
+    r: 5
+  });
+
+  svgAppend(marker, circle);
+
+  defs = domQuery(':scope > defs', parentGfx);
+
+  if (!defs) {
+    defs = svgCreate('defs');
+
+    svgAppend(parentGfx, defs);
+  }
+
+  svgAppend(defs, marker);
+
+  var reference = idToReference(marker.id);
+
+  svgAttr(gfx, markerType, reference);
+};
+
+// helpers //////////
+
+/**
+ * Get functional IRI reference for given ID of fragment within current document.
+ *
+ * @param {string} id
+ *
+ * @return {string}
+ */
+function idToReference(id) {
+  return 'url(#' + id + ')';
+}
+
+/**
+ * Check wether given connection has marker of given type.
+ *
+ * @param {Connection} connection
+ * @param {string} markerType
+ *
+ * @return {boolean}
+ */
+function hasMarker(connection, markerType) {
+  return connection.marker && connection.marker[ markerType.split('-').pop() ];
+}

--- a/test/spec/marker-renderer/index.js
+++ b/test/spec/marker-renderer/index.js
@@ -1,0 +1,6 @@
+import MarkerRenderer from './MarkerRenderer';
+
+export default {
+  __init__: [ 'defaultRenderer' ],
+  defaultRenderer: [ 'type', MarkerRenderer ]
+};


### PR DESCRIPTION
- prefix element IDs
- Add a random string to IDs to allow for multiple `diagram-js-minimap` instances on the same page
- prevent elements with IDs from being copied

related to https://github.com/bpmn-io/bpmn-js/issues/2179

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
