### PR TITLE
fix: set an explicit z-index on the minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js-minimap](https://github.com/bpmn-io/diagram-j
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: set an explicit z-index on the minimap ([#118](https://github.com/bpmn-io/diagram-js-minimap/pull/118))
+
 ## 5.4.0
 
 * `FEAT`: improve render and performance ([#96](https://github.com/bpmn-io/diagram-js-minimap/issues/96), [#81](https://github.com/bpmn-io/diagram-js-minimap/issues/81), [#115](https://github.com/bpmn-io/diagram-js-minimap/pull/115))

--- a/assets/diagram-js-minimap.css
+++ b/assets/diagram-js-minimap.css
@@ -2,6 +2,7 @@
   position: absolute;
   top: 20px;
   right: 20px;
+  z-index: 175; /* keep minimap above canvas overlays (e.g. context pads) but below popup menus */
   overflow: hidden;
   background-color: rgba(255, 255, 255, 0.9);
   border: solid 1px #CCC;


### PR DESCRIPTION
### Proposed Changes

The minimap defined no z-index and stacked by DOM order, so canvas overlays that do set one (e.g. context pads) could render on top of it. Give it a defined stacking order that sits above those overlays but below the popup menu.

Related to https://github.com/camunda/camunda-modeler/issues/6075

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
